### PR TITLE
Add support for OAS version of the definition being uploaded

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Parameter | Description | Required | Default
 **`host`** | URL of SwaggerHub API | false | `api.swaggerhub.com`
 **`protocol`** | Protocol for SwaggerHub API,`http` or `https` | false | `https`
 **`port`** | Port to access SwaggerHub API| false | `443`
+**`oas`** | Version of the OpenApi Specification the definition adheres to | false | `2.0`
 
 ***
 

--- a/src/main/java/io/swagger/swaggerhub/client/SwaggerHubClient.java
+++ b/src/main/java/io/swagger/swaggerhub/client/SwaggerHubClient.java
@@ -98,6 +98,7 @@ public class SwaggerHubClient {
         return getBaseUrl(swaggerHubRequest.getOwner(), swaggerHubRequest.getApi())
                 .addEncodedQueryParameter("version", swaggerHubRequest.getVersion())
                 .addEncodedQueryParameter("isPrivate", Boolean.toString(swaggerHubRequest.isPrivate()))
+                .addEncodedQueryParameter("oas", swaggerHubRequest.getOas())
                 .build();
     }
 

--- a/src/main/java/io/swagger/swaggerhub/client/SwaggerHubRequest.java
+++ b/src/main/java/io/swagger/swaggerhub/client/SwaggerHubRequest.java
@@ -7,6 +7,7 @@ public class SwaggerHubRequest {
     private final String version;
     private final String format;
     private final String swagger;
+    private final String oas;
     private final boolean isPrivate;
 
     public String getApi() {
@@ -29,6 +30,8 @@ public class SwaggerHubRequest {
         return swagger;
     }
 
+    public String getOas() { return oas; }
+
     public boolean isPrivate() {
         return isPrivate;
     }
@@ -40,6 +43,7 @@ public class SwaggerHubRequest {
         this.format = builder.format;
         this.swagger = builder.swagger;
         this.isPrivate = builder.isPrivate;
+        this.oas = builder.oas;
     }
 
     public static class Builder {
@@ -48,6 +52,7 @@ public class SwaggerHubRequest {
         private final String version;
         private String format;
         private String swagger;
+        private String oas;
         private boolean isPrivate;
 
         public Builder(String api, String owner, String version) {
@@ -68,6 +73,11 @@ public class SwaggerHubRequest {
 
         public Builder isPrivate(boolean isPrivate) {
             this.isPrivate = isPrivate;
+            return this;
+        }
+
+        public Builder oas(String oas) {
+            this.oas = oas;
             return this;
         }
 

--- a/src/main/java/io/swagger/swaggerhub/tasks/UploadTask.java
+++ b/src/main/java/io/swagger/swaggerhub/tasks/UploadTask.java
@@ -31,6 +31,7 @@ public class UploadTask extends DefaultTask {
     private int port = 443;
     private String protocol = "https";
     private String format = "json";
+    private String oas = "2.0";
     private static Logger LOGGER = Logging.getLogger(DownloadTask.class);
 
     private SwaggerHubClient swaggerHubClient;
@@ -130,6 +131,12 @@ public class UploadTask extends DefaultTask {
         this.format = format;
     }
 
+    @Input
+    @Optional
+    public String getOas() { return oas; }
+
+    public void setOas(String oas) { this.oas = oas; }
+
     @TaskAction
     public void uploadDefinition() throws GradleException {
 
@@ -141,7 +148,8 @@ public class UploadTask extends DefaultTask {
                 + ", version: " + version
                 + ", inputFile: " + inputFile
                 + ", format: " + format
-                + ", isPrivate: " + isPrivate);
+                + ", isPrivate: " + isPrivate
+                + ", oas: " + oas);
 
         try {
             String content = new String(Files.readAllBytes(Paths.get(inputFile)), Charset.forName("UTF-8"));
@@ -150,6 +158,7 @@ public class UploadTask extends DefaultTask {
                     .swagger(content)
                     .format(format)
                     .isPrivate(isPrivate)
+                    .oas(oas)
                     .build();
 
             swaggerHubClient.saveDefinition(swaggerHubRequest);


### PR DESCRIPTION
Swaggerhub uses different editors for OAS 2.0 vs OAS 3.0.X.  When uploading an OAS 3 definition that was uploaded with the default 2.0 version, the viewing experience is very frustrating.  By providing the OAS version when uploading, the viewing experience is normalized.

The oas parameter is only used on upload and is defaulted to 2.0, so it is backwards compatible.