### PR TITLE
chore: Bump dependency versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
     id 'net.researchgate.release' version '2.8.1'
     // Publishing publicly
     id 'com.gradle.plugin-publish' version '0.14.0'
-    // Publishing to Artifactory
+    // Publishing to maven
     id 'maven-publish'
 }
 
@@ -17,19 +17,17 @@ plugins {
 // * * * * * * * * * * * *
 
 repositories {
-    mavenLocal()
     mavenCentral()
 }
 
 dependencies {
-    implementation     gradleApi()
+    implementation gradleApi()
     implementation group: 'com.squareup.okhttp', name: 'okhttp', version:'2.7.5'
-    implementation group: 'org.apache.commons', name: 'commons-lang3', version:'3.7'
-    testImplementation group: 'com.github.tomakehurst', name: 'wiremock', version:'2.14.0'
+    implementation group: 'org.apache.commons', name: 'commons-lang3', version:'3.12.0'
+    testImplementation group: 'com.github.tomakehurst', name: 'wiremock', version:'2.27.2'
     testImplementation gradleTestKit()
-    testImplementation 'junit:junit:4+'
-    testImplementation group: 'io.swagger', name: 'swagger-parser', version:'1.0.34'
-
+    testImplementation 'junit:junit:4.13'
+    testImplementation group: 'io.swagger', name: 'swagger-parser', version:'1.0.55'
 }
 
 // * * * * * * * * * * * *


### PR DESCRIPTION
Updating the following dependencies:
* `commons-lang3` 3.7 -> 3.12.0
* `wiremock` 2.14.0 -> 2.27.2
* `junit` 4+ -> 4.13
* `swagger-parser` 1.0.34 -> 1.0.55