### PR TITLE
bump dependencies version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,12 +22,12 @@ repositories {
 
 dependencies {
     implementation gradleApi()
-    implementation group: 'com.squareup.okhttp', name: 'okhttp', version:'2.7.5'
+    implementation group: 'com.squareup.okhttp3', name: 'okhttp', version:'4.10.0'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version:'3.12.0'
-    testImplementation group: 'com.github.tomakehurst', name: 'wiremock', version:'2.27.2'
+    testImplementation group: 'com.github.tomakehurst', name: 'wiremock-jre8-standalone', version:'2.35.0'
     testImplementation gradleTestKit()
     testImplementation 'junit:junit:4.13'
-    testImplementation group: 'io.swagger', name: 'swagger-parser', version:'1.0.55'
+    testImplementation group: 'io.swagger', name: 'swagger-parser', version:'1.0.65'
 }
 
 // * * * * * * * * * * * *

--- a/src/main/java/io/swagger/swaggerhub/client/SwaggerHubClient.java
+++ b/src/main/java/io/swagger/swaggerhub/client/SwaggerHubClient.java
@@ -1,13 +1,12 @@
 package io.swagger.swaggerhub.client;
 
-import com.squareup.okhttp.HttpUrl;
-import com.squareup.okhttp.MediaType;
-import com.squareup.okhttp.OkHttpClient;
-import com.squareup.okhttp.Request;
-import com.squareup.okhttp.RequestBody;
-import com.squareup.okhttp.Response;
+import okhttp3.HttpUrl;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
 import org.gradle.api.GradleException;
-import io.swagger.swaggerhub.client.SwaggerHubRequest;
 
 import java.io.IOException;
 


### PR DESCRIPTION
This PR updates dependencies due to security issue
`okhttp 2.7.5 -> 4.10.0`
`swagger-parser 1.0.55 -> 1.0.65`
`wiremock 2.27.2 -> 2.35.0`
