### PR TITLE
Update plugin-publish version to 1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,28 +26,11 @@ The pattern of usage is likely to depend on whether a [code first or design firs
     - [swagger-inflector](https://github.com/swagger-api/swagger-inflector) to automatically wire up the API definition to the implementation and provide out-of-the-box mocking.
 
 ## Installation
-### Gradle 2.1 and higher
 
 ```
 plugins {
   id "io.swagger.swaggerhub" version "1.0.1"
 }
-```
-### Gradle 1.x and 2.0
-
-```
-buildscript {
-  repositories {
-    maven {
-      url "https://plugins.gradle.org/m2/"
-    }
-  }
-  dependencies {
-    classpath "gradle.plugin.io.swagger:swaggerhub:1.0.1"
-  }
-}
-
-apply plugin: "io.swagger.swaggerhub"
 ```
 
 ## Tasks

--- a/build.gradle
+++ b/build.gradle
@@ -1,20 +1,9 @@
-// * * * * * * * * * * * *
-// Plugins
-// * * * * * * * * * * * *
-
 plugins {
     id 'groovy'
     id 'java-gradle-plugin'
+    id 'com.gradle.plugin-publish' version '1.2.0'
     id 'net.researchgate.release' version '2.8.1'
-    // Publishing publicly
-    id 'com.gradle.plugin-publish' version '0.14.0'
-    // Publishing to maven
-    id 'maven-publish'
 }
-
-// * * * * * * * * * * * *
-// Dependencies
-// * * * * * * * * * * * *
 
 repositories {
     mavenCentral()
@@ -26,51 +15,23 @@ dependencies {
     implementation group: 'org.apache.commons', name: 'commons-lang3', version:'3.12.0'
     testImplementation group: 'com.github.tomakehurst', name: 'wiremock-jre8-standalone', version:'2.35.0'
     testImplementation gradleTestKit()
-    testImplementation 'junit:junit:4.13'
+    testImplementation 'junit:junit:4.13.2'
     testImplementation group: 'io.swagger', name: 'swagger-parser', version:'1.0.65'
 }
 
-// * * * * * * * * * * * *
-// Project configuration
-// * * * * * * * * * * * *
+version = '1.1.0'
+group = 'io.swagger'
 
-project.description     = 'Gradle Plugin for SwaggerHub'
-project.group           = 'io.swagger'
-
-project.ext.name        = 'swaggerhub'
-project.ext.pluginId    = 'io.swagger.swaggerhub'
-project.ext.scm         = 'scm:git@github.com:swagger-api/swaggerhub-gradle-plugin.git'
-project.ext.url         = 'https://github.com/swagger-api/swaggerhub-gradle-plugin'
-
-// Configuration for: java-gradle-plugin
 gradlePlugin {
+    website = 'https://github.com/swagger-api/swaggerhub-gradle-plugin'
+    vcsUrl = 'https://github.com/swagger-api/swaggerhub-gradle-plugin'
     plugins {
         swaggerhub {
-            id = project.pluginId
+            id = 'io.swagger.swaggerhub'
             implementationClass = 'io.swagger.swaggerhub.SwaggerHubPlugin'
-        }
-    }
-}
-
-// * * * * * * * * * * * *
-// Publishing
-// * * * * * * * * * * * *
-
-
-// Publishing to plugins.gradle.org
-// --------------------------------
-
-// Configuration for: com.gradle.plugin-publish
-pluginBundle {
-    website = project.url
-    vcsUrl = project.scm
-    tags = ['swagger', 'swaggerhub', 'openapi', 'api']
-
-    plugins {
-        swaggerhubPlugin {
-            displayName = 'SwaggerHub Gradle Plugin '
-            description = project.description
-            id          = project.pluginId
+            displayName = 'SwaggerHub Gradle Plugin'
+            description = 'Gradle Plugin for SwaggerHub'
+            tags.set(['swagger', 'swaggerhub', 'openapi', 'api'])
         }
     }
 }


### PR DESCRIPTION
Updating the Gradle publishing plugin version from `0.14.0` to `1.2.0`

I've updated the format of the build.gradle to reflect the version 1.0+ format:
https://plugins.gradle.org/docs/publish-plugin