### PR TITLE
Fix build warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     testImplementation group: 'io.swagger', name: 'swagger-parser', version:'1.0.65'
 }
 
-version = '1.1.0'
+version = '1.1.1-SNAPSHOT'
 group = 'io.swagger'
 
 gradlePlugin {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.1.0
+version=1.1.1-SNAPSHOT

--- a/src/main/java/io/swagger/swaggerhub/client/SwaggerHubClient.java
+++ b/src/main/java/io/swagger/swaggerhub/client/SwaggerHubClient.java
@@ -11,6 +11,8 @@ import org.gradle.api.GradleException;
 import java.io.IOException;
 
 public class SwaggerHubClient {
+    private static final String DOWNLOAD_FAILED_ERROR = "Failed to download API definition: ";
+    private static final String UPLOAD_FAILED_ERROR = "Failed to upload API definition: ";
     private final OkHttpClient client;
     private final String host;
     private final int port;
@@ -29,22 +31,20 @@ public class SwaggerHubClient {
 
     public String getDefinition(SwaggerHubRequest swaggerHubRequest) throws GradleException {
         HttpUrl httpUrl = getDownloadUrl(swaggerHubRequest);
-        MediaType mediaType = MediaType.parse("application/" + swaggerHubRequest.getFormat());
-
+        MediaType mediaType = getMediaType(swaggerHubRequest);
         Request requestBuilder = buildGetRequest(httpUrl, mediaType);
 
-        final String jsonResponse;
-        try {
-            final Response response = client.newCall(requestBuilder).execute();
-            if (!response.isSuccessful()) {
-                throw new GradleException(String.format("Failed to download API definition: %s", response.body().string()));
+        try (Response response = client.newCall(requestBuilder).execute()) {
+            if (response.body() == null) {
+                throw new GradleException(DOWNLOAD_FAILED_ERROR + "Response body is empty");
+            } else if (!response.isSuccessful()) {
+                throw new GradleException(DOWNLOAD_FAILED_ERROR + response.body().string());
             } else {
-                jsonResponse = response.body().string();
+                return response.body().string();
             }
         } catch (IOException e) {
-            throw new GradleException("Failed to download API definition", e);
+            throw new GradleException(DOWNLOAD_FAILED_ERROR, e);
         }
-        return jsonResponse;
     }
 
     private Request buildGetRequest(HttpUrl httpUrl, MediaType mediaType) {
@@ -60,21 +60,18 @@ public class SwaggerHubClient {
 
     public void saveDefinition(SwaggerHubRequest swaggerHubRequest) throws GradleException {
         HttpUrl httpUrl = getUploadUrl(swaggerHubRequest);
-        MediaType mediaType = MediaType.parse("application/" + swaggerHubRequest.getFormat());
+        MediaType mediaType = getMediaType(swaggerHubRequest);
+        Request httpRequest = buildPostRequest(httpUrl, mediaType, swaggerHubRequest.getSwagger());
 
-        final Request httpRequest = buildPostRequest(httpUrl, mediaType, swaggerHubRequest.getSwagger());
-
-        try {
-            Response response = client.newCall(httpRequest).execute();
-            if (!response.isSuccessful()) {
-                throw new GradleException(
-                        String.format("Failed to upload definition: %s", response.body().string())
-                );
+        try (Response response = client.newCall(httpRequest).execute()) {
+            if (response.body() == null) {
+                throw new GradleException(UPLOAD_FAILED_ERROR + "Response body is empty");
+            } else if (!response.isSuccessful()) {
+                throw new GradleException(UPLOAD_FAILED_ERROR + response.body().string());
             }
         } catch (IOException e) {
-            throw new GradleException("Failed to upload definition", e);
+            throw new GradleException(UPLOAD_FAILED_ERROR, e);
         }
-        return;
     }
 
     private Request buildPostRequest(HttpUrl httpUrl, MediaType mediaType, String content) {
@@ -83,7 +80,7 @@ public class SwaggerHubClient {
                 .addHeader("Content-Type", mediaType.toString())
                 .addHeader("Authorization", token)
                 .addHeader("User-Agent", "swaggerhub-gradle-plugin")
-                .post(RequestBody.create(mediaType, content))
+                .post(RequestBody.create(content, mediaType))
                 .build();
     }
 
@@ -109,5 +106,14 @@ public class SwaggerHubClient {
                 .addPathSegment(APIS)
                 .addEncodedPathSegment(owner)
                 .addEncodedPathSegment(api);
+    }
+
+    private MediaType getMediaType(SwaggerHubRequest swaggerHubRequest) {
+        String headerFormat = "application/%s; charset=utf-8";
+        MediaType mediaType = MediaType.parse(String.format(headerFormat, swaggerHubRequest.getFormat()));
+        if (mediaType == null) {
+            mediaType = MediaType.parse(String.format(headerFormat, "json"));
+        }
+        return mediaType;
     }
 }

--- a/src/main/java/io/swagger/swaggerhub/tasks/DownloadTask.java
+++ b/src/main/java/io/swagger/swaggerhub/tasks/DownloadTask.java
@@ -8,13 +8,12 @@ import org.gradle.api.GradleException;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Optional;
-import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
 import org.slf4j.Logger;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
@@ -124,12 +123,8 @@ public class DownloadTask extends DefaultTask {
     public void downloadDefinition() throws GradleException {
         SwaggerHubClient swaggerHubClient = new SwaggerHubClient(host, port, protocol, token);
 
-        LOGGER.info("Downloading from " + host
-                + ": api:" + api
-                + ", owner:" + owner
-                + ", version:" + version
-                + ", format:" + format
-                + ", outputFile:" + outputFile);
+        LOGGER.info("Downloading from {}: api: {}, owner: {}, version: {}, format: {}, outputFile: {}",
+                host, api, owner, version, format, outputFile);
 
         SwaggerHubRequest swaggerHubRequest = new SwaggerHubRequest.Builder(api, owner, version)
                 .format(format)
@@ -140,16 +135,16 @@ public class DownloadTask extends DefaultTask {
             File file = new File(outputFile);
 
             setUpOutputDir(file);
-            Files.write(Paths.get(outputFile), swaggerJson.getBytes(Charset.forName("UTF-8")));
+            Files.write(Paths.get(outputFile), swaggerJson.getBytes(StandardCharsets.UTF_8));
         } catch (IOException | GradleException e) {
             throw new GradleException(e.getMessage(), e);
         }
     }
 
-    private void setUpOutputDir(File file) {
-        final File parentFile = file.getParentFile();
+    private void setUpOutputDir(File file) throws IOException {
+        File parentFile = file.getParentFile();
         if (parentFile != null) {
-            parentFile.mkdirs();
+            Files.createDirectories(file.getParentFile().toPath());
         }
     }
 }

--- a/src/main/java/io/swagger/swaggerhub/tasks/UploadTask.java
+++ b/src/main/java/io/swagger/swaggerhub/tasks/UploadTask.java
@@ -12,7 +12,7 @@ import org.gradle.api.tasks.TaskAction;
 import org.slf4j.Logger;
 
 import java.io.IOException;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
@@ -142,17 +142,11 @@ public class UploadTask extends DefaultTask {
 
         swaggerHubClient = new SwaggerHubClient(host, port, protocol, token);
 
-        LOGGER.info("Uploading to " + host
-                + ": api: " + api
-                + ", owner: " + owner
-                + ", version: " + version
-                + ", inputFile: " + inputFile
-                + ", format: " + format
-                + ", isPrivate: " + isPrivate
-                + ", oas: " + oas);
+        LOGGER.info("Uploading to {}: api: {}, owner: {}, version: {}, inputFile: {}, format: {}, isPrivate: {}, oas: {} ",
+                host, api, owner, version, inputFile, format, isPrivate, oas);
 
         try {
-            String content = new String(Files.readAllBytes(Paths.get(inputFile)), Charset.forName("UTF-8"));
+            String content = new String(Files.readAllBytes(Paths.get(inputFile)), StandardCharsets.UTF_8);
 
             SwaggerHubRequest swaggerHubRequest = new SwaggerHubRequest.Builder(api, owner, version)
                     .swagger(content)


### PR DESCRIPTION
- The order of parameters in `RequestBody.create` was changed with okhttp3. This changes from the deprecated API to the new one
- Handling `mediaType` inputted as null