### PR TITLE
Support for on-premise SwaggerHub Deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,19 +47,21 @@ swaggerhubDownload {
 ```
 
 #### Parameters
-Parameter | Description | Required | Default
---------- | ----------- | --------- | -------
-**`api`** | API name | true  | -
-**`owner`** | API owner | true | -
-**`version`** | API version | true | -  
-**`outputFile`** | API definition is written to this file | true | -
-**`token`** | SwaggerHub API key, required to access private definitions | false | -
-**`format`** | API definition format, `json` or `yaml` | false | `json`
-**`host`** | URL of SwaggerHub API | false | `api.swaggerhub.com`
-**`protocol`** | Protocol for SwaggerHub API,`http` or `https` | false | `https`
-**`port`** | Port to access SwaggerHub API| false | `443`
-**`oas`** | Version of the OpenApi Specification the definition adheres to | false | `2.0`
-**`resolved`** | Download a resolved version of the API definition              | false | `false`
+Parameter | Description                                                                                        | Required | Default
+--------- |----------------------------------------------------------------------------------------------------| --------- | -------
+**`api`** | API name                                                                                           | true  | -
+**`owner`** | API owner                                                                                          | true | -
+**`version`** | API version                                                                                        | true | -  
+**`outputFile`** | API definition is written to this file                                                             | true | -
+**`token`** | SwaggerHub API key, required to access private definitions                                         | false | -
+**`format`** | API definition format, `json` or `yaml`                                                            | false | `json`
+**`host`** | URL of SwaggerHub API                                                                              | false | `api.swaggerhub.com`
+**`protocol`** | Protocol for SwaggerHub API,`http` or `https`                                                      | false | `https`
+**`port`** | Port to access SwaggerHub API                                                                      | false | `443`
+**`oas`** | Version of the OpenApi Specification the definition adheres to                                     | false | `2.0`
+**`resolved`** | Download a resolved version of the API definition                                                  | false | `false`
+**`onPremise`** | Uses the API path suffix for on-premise SwaggerHub deployments                                     | false | `false`
+**`onPremiseAPISuffix`** | Custom API Suffix path for any future changes in SwaggerHub API pattern for on-premise deployments | false | `/v1`
 ***
 
 ### swaggerhubUpload
@@ -122,3 +124,5 @@ Parameter | Description | Required | Default
 **`host`** | URL of SwaggerHub API | false | `api.swaggerhub.com`
 **`protocol`** | Protocol for SwaggerHub API,`http` or `https` | false | `https`
 **`port`** | Port to access SwaggerHub API| false | `443`
+**`onPremise`** | Uses the API path suffix for on-premise SwaggerHub deployments                                     | false | `false`
+**`onPremiseAPISuffix`** | Custom API Suffix path for any future changes in SwaggerHub API pattern for on-premise deployments | false | `/v1`

--- a/src/main/java/io/swagger/swaggerhub/client/SwaggerHubClient.java
+++ b/src/main/java/io/swagger/swaggerhub/client/SwaggerHubClient.java
@@ -18,15 +18,23 @@ public class SwaggerHubClient {
     private final int port;
     private final String token;
     private final String protocol;
+    private final Boolean onPremise;
+    private final String onPremiseAPISuffix;
     private static final String APIS = "apis";
 
 
-    public SwaggerHubClient(String host, int port, String protocol, String token) {
+    public SwaggerHubClient(String host, int port, String protocol, String token) { // TODO: Worth removing after due consideration
+        this(host, port, protocol, token, false, null);
+    }
+
+    public SwaggerHubClient(String host, int port, String protocol, String token, Boolean onPremise, String onPremiseAPISuffix) {
         client = new OkHttpClient();
         this.host = host;
         this.port = port;
         this.protocol = protocol;
         this.token = token;
+        this.onPremise = onPremise;
+        this.onPremiseAPISuffix = onPremiseAPISuffix;
     }
 
     public String getDefinition(SwaggerHubRequest swaggerHubRequest) throws GradleException {
@@ -104,6 +112,7 @@ public class SwaggerHubClient {
                 .scheme(protocol)
                 .host(host)
                 .port(port)
+                .addPathSegment(onPremise ? onPremiseAPISuffix : "")
                 .addPathSegment(APIS)
                 .addEncodedPathSegment(owner)
                 .addEncodedPathSegment(api);

--- a/src/main/java/io/swagger/swaggerhub/tasks/DownloadTask.java
+++ b/src/main/java/io/swagger/swaggerhub/tasks/DownloadTask.java
@@ -33,6 +33,8 @@ public class DownloadTask extends DefaultTask {
     private Integer port = 443;
     private String protocol = "https";
     private Boolean resolved = false;
+    private Boolean onPremise = false;
+    private String onPremiseAPISuffix = "/v1";
 
     @Input
     public String getOwner() {
@@ -130,13 +132,32 @@ public class DownloadTask extends DefaultTask {
         this.resolved = resolved;
     }
 
+    @Input
+    @Optional
+    public Boolean getOnPremise() {
+        return onPremise;
+    }
+
+    public void setOnPremise(Boolean onPremise) {
+        this.onPremise = onPremise;
+    }
+
+    @Input
+    @Optional
+    public String getOnPremiseAPISuffix() {
+        return onPremiseAPISuffix;
+    }
+
+    public void setOnPremiseAPISuffix(String onPremiseAPISuffix) {
+        this.onPremiseAPISuffix = onPremiseAPISuffix;
+    }
 
     @TaskAction
     public void downloadDefinition() throws GradleException {
-        SwaggerHubClient swaggerHubClient = new SwaggerHubClient(host, port, protocol, token);
+        SwaggerHubClient swaggerHubClient = new SwaggerHubClient(host, port, protocol, token, onPremise, onPremiseAPISuffix);
 
-        LOGGER.info("Downloading from {}: api: {}, owner: {}, version: {}, format: {}, resolved: {}, outputFile: {}",
-                host, api, owner, version, format, resolved, outputFile);
+        LOGGER.info("Downloading from {}: api: {}, owner: {}, version: {}, format: {}, resolved: {}, outputFile: {}, onPremise: {}, onPremiseAPISuffix: {}",
+                host, api, owner, version, format, resolved, outputFile, onPremise, onPremiseAPISuffix);
 
         SwaggerHubRequest swaggerHubRequest = new SwaggerHubRequest.Builder(api, owner, version)
                 .format(format)

--- a/src/main/java/io/swagger/swaggerhub/tasks/UploadTask.java
+++ b/src/main/java/io/swagger/swaggerhub/tasks/UploadTask.java
@@ -33,6 +33,8 @@ public class UploadTask extends DefaultTask {
     private String protocol = "https";
     private String format = "json";
     private String oas = "2.0";
+    private Boolean onPremise = false;
+    private String onPremiseAPISuffix = "/v1";
 
     private SwaggerHubClient swaggerHubClient;
 
@@ -137,13 +139,34 @@ public class UploadTask extends DefaultTask {
 
     public void setOas(String oas) { this.oas = oas; }
 
+    @Input
+    @Optional
+    public Boolean getOnPremise() {
+        return onPremise;
+    }
+
+    public void setOnPremise(Boolean onPremise) {
+        this.onPremise = onPremise;
+    }
+
+    @Input
+    @Optional
+    public String getOnPremiseAPISuffix() {
+        return onPremiseAPISuffix;
+    }
+
+    public void setOnPremiseAPISuffix(String onPremiseAPISuffix) {
+        this.onPremiseAPISuffix = onPremiseAPISuffix;
+    }
+
     @TaskAction
     public void uploadDefinition() throws GradleException {
 
-        swaggerHubClient = new SwaggerHubClient(host, port, protocol, token);
+        swaggerHubClient = new SwaggerHubClient(host, port, protocol, token, onPremise, onPremiseAPISuffix);
 
-        LOGGER.info("Uploading to {}: api: {}, owner: {}, version: {}, inputFile: {}, format: {}, isPrivate: {}, oas: {} ",
-                host, api, owner, version, inputFile, format, isPrivate, oas);
+        LOGGER.info("Uploading to {}: api: {}, owner: {}, version: {}, inputFile: {}, format: {}, isPrivate: {}, oas: {}," +
+                        " onPremise: {}, onPremiseAPISuffix: {} ",
+                host, api, owner, version, inputFile, format, isPrivate, oas, onPremise, onPremiseAPISuffix);
 
         try {
             String content = new String(Files.readAllBytes(Paths.get(inputFile)), StandardCharsets.UTF_8);


### PR DESCRIPTION
Fix of the issue logged #29.

The plugin was not designed to work with `/v1` API suffix that's necessary with the on-premise deployments of Swagger Hub.