### PR TITLE
BUGFIX: default OnPremiseAPISuffix chnaged to 'v1' from '/v1'

### DIFF
--- a/src/main/java/io/swagger/swaggerhub/tasks/DownloadTask.java
+++ b/src/main/java/io/swagger/swaggerhub/tasks/DownloadTask.java
@@ -34,7 +34,7 @@ public class DownloadTask extends DefaultTask {
     private String protocol = "https";
     private Boolean resolved = false;
     private Boolean onPremise = false;
-    private String onPremiseAPISuffix = "/v1";
+    private String onPremiseAPISuffix = "v1";
 
     @Input
     public String getOwner() {

--- a/src/main/java/io/swagger/swaggerhub/tasks/UploadTask.java
+++ b/src/main/java/io/swagger/swaggerhub/tasks/UploadTask.java
@@ -34,7 +34,7 @@ public class UploadTask extends DefaultTask {
     private String format = "json";
     private String oas = "2.0";
     private Boolean onPremise = false;
-    private String onPremiseAPISuffix = "/v1";
+    private String onPremiseAPISuffix = "v1";
 
     private SwaggerHubClient swaggerHubClient;
 


### PR DESCRIPTION
OkHttp adds the slashes as necessary, but can't navigate if there is `//` in the API path.
Setting the default suffix to `/v1` was evaluating to `host//v1/apis...` and failing to fetch the spec with a 404